### PR TITLE
Show feedbacks tagged with "Poll Feedback" if they are marked #public

### DIFF
--- a/lib/tribevibe/core/core.ex
+++ b/lib/tribevibe/core/core.ex
@@ -103,10 +103,17 @@ defmodule Tribevibe.Core do
           |> sort_by_newest
           |> Enum.take(10)
 
-          { :commit, %{positive: positive, constructive: constructive} }
+          poll_feedback = feedbacks
+          |> filter_feedbacks_by_tag("Poll Feedback")
+          |> filter_public_feedbacks
+          |> mark_original_posters
+          |> sort_by_newest
+          |> Enum.take(10)
+
+          { :commit, %{positive: positive, constructive: constructive, poll_feedback: poll_feedback} }
         {:ok, %HTTPoison.Response{status_code: 404}} ->
           Logger.error("Failed to fetch feedbacks")
-          { :ignore, %{positive: [], constructive: []} }
+          { :ignore, %{positive: [], constructive: [], poll_feedback: []} }
         {:error, %HTTPoison.Error{reason: reason}} ->
           Logger.error("API error with feedbacks: #{inspect reason}")
           { :ignore, reason }

--- a/lib/tribevibe_web/controllers/vibe_controller.ex
+++ b/lib/tribevibe_web/controllers/vibe_controller.ex
@@ -208,8 +208,9 @@ defmodule TribevibeWeb.VibeController do
         title "FeedbackBlock"
         description "Block containting positive and constructive feedback"
         properties do
-          positive Schema.ref(:Feedbacks), "Newest positive #public feedbacks."
-          constructive Schema.ref(:Feedbacks), "Newest constructive #public feedbacks."
+          positive Schema.ref(:Feedbacks), "Newest #public feedbacks tagged Positive."
+          constructive Schema.ref(:Feedbacks), "Newest #public feedbacks tagged Constructive."
+          poll_feedback Schema.ref(:Feedbacks), "Newest #public feedbacks tagged Poll Feedback."
         end
       end,
       Dashboard: swagger_schema do

--- a/lib/tribevibe_web/views/vibe_view.ex
+++ b/lib/tribevibe_web/views/vibe_view.ex
@@ -13,7 +13,8 @@ defmodule TribevibeWeb.VibeView do
   def render("feedbacks.json", %{feedbacks: feedbacks}) do
     %{
       positive: render_many(feedbacks.positive, VibeView, "feedback.json"),
-      constructive: render_many(feedbacks.constructive, VibeView, "feedback.json")
+      constructive: render_many(feedbacks.constructive, VibeView, "feedback.json"),
+      poll_feedback: render_many(feedbacks.poll_feedback, VibeView, "feedback.json")
     }
   end
 
@@ -37,10 +38,7 @@ defmodule TribevibeWeb.VibeView do
     %{engagements: render_many(dashboard.engagements, VibeView, "engagement.json"),
       engagement: dashboard.engagement,
       metrics: dashboard.metrics,
-      feedbacks: %{
-        positive: render_many(dashboard.feedbacks.positive, VibeView, "feedback.json"),
-        constructive: render_many(dashboard.feedbacks.constructive, VibeView, "feedback.json")
-      }
+      feedbacks: render("feedbacks.json", %{feedbacks: dashboard.feedbacks})
     }
   end
 

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -274,11 +274,15 @@
       "title": "FeedbackBlock",
       "properties": {
         "positive": {
-          "description": "Newest positive #public feedbacks.",
+          "description": "Newest #public feedbacks tagged Positive.",
+          "$ref": "#/definitions/Feedbacks"
+        },
+        "poll_feedback": {
+          "description": "Newest #public feedbacks tagged Poll Feedback.",
           "$ref": "#/definitions/Feedbacks"
         },
         "constructive": {
-          "description": "Newest constructive #public feedbacks.",
+          "description": "Newest #public feedbacks tagged Constructive.",
           "$ref": "#/definitions/Feedbacks"
         }
       },


### PR DESCRIPTION
Officevibe asks at the end of weekly questionnaire something along the lines of "Do you have anything else on your mind?". Answers to these questions end up tagged with `Poll Feedback`, and they are not currently shown.

These answers don't seem to have any replies on them - perhaps they are shown in a different way at Officevibe? The answers also seem to be more like general thoughts about the company - definitely something that we would like to display on the service.

This PR adds these as a separate field on feedback responses, so UI would need to do minor changes to display them.